### PR TITLE
fix: standardize field lengths in response2df

### DIFF
--- a/tests/test_plot_gdf.py
+++ b/tests/test_plot_gdf.py
@@ -1,0 +1,44 @@
+from urbanworm import UrbanDataSet
+
+def main():
+    print("Step 1: Initialize dataset and load building footprints")
+    # Smaller bounding box for quicker testing
+    bbox = (-82.92575, 42.441675, -82.92525, 42.442025)
+    data = UrbanDataSet()
+    result = data.bbox2Buildings(bbox, source='osm')
+    print(result)
+    print(f"Loaded {len(data.units)} buildings")
+
+    print("\nStep 2: Define model and multiple prompts")
+    system = '''
+    Given a top view image, you are going to roughly estimate house conditions.
+    Your answer should be based only on your observation.
+    The format of your response must include question, answer (yes or no), explanation (within 50 words).
+    '''
+    prompt = {
+        'top': '''
+        Is there any damage on the roof?
+        Is there a solar panel on the roof?
+        '''
+    }
+
+    print("\nStep 3: Run inference using loopUnitChat")
+    data.loopUnitChat(
+        model='gemma3:12b',
+        system=system,
+        prompt=prompt,
+        type='top',
+        epsg=4326,  # WGS84 for visualization
+        multi=False,
+        output_gdf=False
+    )
+
+    print("\nStep 4: Convert results to GeoDataFrame")
+    data.to_gdf()
+
+    print("\nStep 5: Plot")
+    data.plot_gdf()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_response2df.py
+++ b/tests/test_response2df.py
@@ -1,0 +1,27 @@
+# tests/test_response2df.py
+from urbanworm.utils import response2df
+
+class Dummy:
+    def __init__(self, question, answer, explanation):
+        self.question = question
+        self.answer = answer
+        self.explanation = explanation
+
+image_paths = [
+    'docs/data/test1.jpg',
+    'docs/data/test2.jpg',
+    'docs/data/test3.jpg'
+]
+
+qna_dict = {
+    'responses': [
+        [Dummy("Is roof damaged?", True, "Looks okay.")],
+        [Dummy("Is roof damaged?", False, "Roof appears damaged.")],
+        [Dummy("Is roof damaged?", True, "No visible damage.")]
+    ],
+    'img': image_paths,
+    'imgBase64': ['b64_1', 'b64_2', 'b64_3']  # 这里用 dummy base64 数据
+}
+
+df = response2df(qna_dict)
+print(df)


### PR DESCRIPTION
This PR fixes a `ValueError: All arrays must be of the same length` caused by inconsistent field lengths in the `extract_qna` logic used by `response2df()`.

Changes implemented in my fork ([Ellen-Tian/urbanworm](https://github.com/Ellen-Tian/urbanworm)):

- Rewrote the field extraction logic to pad missing entries with `None`
- Ensured all arrays passed to `pd.DataFrame()` are of equal length
- Verified the fix with test images in `docs/data/` using `test_response2df.py`

This resolves issue #24.