### PR TITLE
Pull Request: Improve robustness of getSV and response2gdf

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,36 @@
+import pytest
+from urbanworm.UrbanDataSet import UrbanDataSet
+from urbanworm.utils import response2gdf
+
+
+def test_export_geojson_like_issue():
+    """Test export() with empty from_loopUnitChat to simulate ValueError scenario"""
+    dataset = UrbanDataSet()
+
+    fake_qna = []
+    dataset.results = {
+        'from_loopUnitChat': fake_qna,
+        'base64_imgs': {},
+        'coords': [],
+        'meta': []
+    }
+
+    with pytest.raises(ValueError, match="No response found in the input dictionary"):
+        dataset.export(file_name="./test_output_issue.geojson", out_type='geojson')
+
+def test_response2gdf_empty_input():
+    """Test response2gdf with completely empty input"""
+    with pytest.raises(ValueError):
+        response2gdf([])
+
+
+def test_response2gdf_nested_empty_input():
+    """Test response2gdf with nested empty input"""
+    with pytest.raises(ValueError):
+        response2gdf([[]])
+
+
+def test_response2gdf_missing_nesting():
+    """Test response2gdf with missing level of nesting"""
+    with pytest.raises(ValueError):
+        response2gdf([["Q", "A"]])

--- a/tests/test_getSV.py
+++ b/tests/test_getSV.py
@@ -10,7 +10,7 @@ MAPILLARY_KEY = ""
 
 CSV_PATH = r"C:\Users\L1ght\OneDrive\Umich-School\Xiaohao-Project\Urban-Worm\ground_truth\groundtruth_1_labeled.csv"
 
-TEST_INDEX = 97
+TEST_INDEX = 155
 NUM_TRIALS = 1
 
 OUTPUT_DIR = "testGetSV"
@@ -59,7 +59,7 @@ def test_getsv_focus_on_house():
             key=MAPILLARY_KEY,
             multi=True,
             heading=None,
-            pitch=10,
+            pitch=5,
             fov=45,
             width=640,
             height=480
@@ -79,7 +79,40 @@ def test_getsv_focus_on_house():
     except Exception as e:
         print(f"Error in focused getSV test: {e}")
 
+def test_getsv_pitch():
+    df = pd.read_csv(CSV_PATH)
+    lon, lat = eval(df.loc[TEST_INDEX, "geometry_coordinates"])
+    centroid = Point(lon, lat)
+
+    print(f"\n=== Testing focused getSV at index {TEST_INDEX} ===")
+    try:
+        images = getSV(
+            centroid=centroid,
+            epsg=3857,
+            key=MAPILLARY_KEY,
+            multi=True,
+            heading=None,
+            pitch=5,
+            fov=30,
+            width=640,
+            height=480
+        )
+        if not images:
+            print("No image returned.")
+        else:
+            print(f"Returned {len(images)} focused image(s).")
+            for j, img in enumerate(images):
+                out_path = os.path.join(
+                    OUTPUT_DIR,
+                    f"pitch_sv_index{TEST_INDEX}_img{j + 1}.jpg"
+                )
+                with open(out_path, "wb") as f:
+                    f.write(base64.b64decode(img))
+                print(f"Saved focused image {j + 1} to: {out_path}")
+    except Exception as e:
+        print(f"Error in focused getSV test: {e}")
 
 if __name__ == "__main__":
     # test_getsv_consistency()
     test_getsv_focus_on_house()
+    test_getsv_pitch()

--- a/tests/test_getSV.py
+++ b/tests/test_getSV.py
@@ -10,8 +10,8 @@ MAPILLARY_KEY = ""
 
 CSV_PATH = r"C:\Users\L1ght\OneDrive\Umich-School\Xiaohao-Project\Urban-Worm\ground_truth\groundtruth_1_labeled.csv"
 
-TEST_INDEX = 251
-NUM_TRIALS = 5
+TEST_INDEX = 97
+NUM_TRIALS = 1
 
 OUTPUT_DIR = "testGetSV"
 os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -29,12 +29,7 @@ def test_getsv_consistency():
                 centroid=centroid,
                 epsg=3857,
                 key=MAPILLARY_KEY,
-                multi=True,
-                heading=None,
-                pitch=10,
-                fov=80,
-                width=400,
-                height=300
+                multi=True
             )
             if not images:
                 print("No image returned.")
@@ -43,7 +38,7 @@ def test_getsv_consistency():
                 for j, img in enumerate(images):
                     out_path = os.path.join(
                         OUTPUT_DIR,
-                        f"debug_sv_index{TEST_INDEX}_trial{i + 1}_img{j + 1}.jpg"
+                        f"original_sv_index{TEST_INDEX}_trial{i + 1}_img{j + 1}.jpg"
                     )
                     with open(out_path, "wb") as f:
                         f.write(base64.b64decode(img))
@@ -51,5 +46,40 @@ def test_getsv_consistency():
         except Exception as e:
             print(f"Error on trial {i + 1}: {e}")
 
+def test_getsv_focus_on_house():
+    df = pd.read_csv(CSV_PATH)
+    lon, lat = eval(df.loc[TEST_INDEX, "geometry_coordinates"])
+    centroid = Point(lon, lat)
+
+    print(f"\n=== Testing focused getSV at index {TEST_INDEX} ===")
+    try:
+        images = getSV(
+            centroid=centroid,
+            epsg=3857,
+            key=MAPILLARY_KEY,
+            multi=True,
+            heading=None,
+            pitch=10,
+            fov=45,
+            width=640,
+            height=480
+        )
+        if not images:
+            print("No image returned.")
+        else:
+            print(f"Returned {len(images)} focused image(s).")
+            for j, img in enumerate(images):
+                out_path = os.path.join(
+                    OUTPUT_DIR,
+                    f"focused_sv_index{TEST_INDEX}_img{j + 1}.jpg"
+                )
+                with open(out_path, "wb") as f:
+                    f.write(base64.b64decode(img))
+                print(f"Saved focused image {j + 1} to: {out_path}")
+    except Exception as e:
+        print(f"Error in focused getSV test: {e}")
+
+
 if __name__ == "__main__":
-    test_getsv_consistency()
+    # test_getsv_consistency()
+    test_getsv_focus_on_house()

--- a/tests/test_getSV.py
+++ b/tests/test_getSV.py
@@ -6,7 +6,7 @@ from urbanworm.utils import getSV
 from urbanworm.utils import calculate_bearing
 
 # Mapillary API Key
-MAPILLARY_KEY = "MLYATeA2wLvIqBVnUyP41955Mzz2RelHW9jMdHMitd2tyLZBC5WVkMfZBae72LGARBhbsg8n8R14WsVAEx328rDnV6pXvZAFLd61tmvriVapmJXh4lOC4AxJZCHKV9GMgZDZD"
+MAPILLARY_KEY = ""
 
 CSV_PATH = r"C:\Users\L1ght\OneDrive\Umich-School\Xiaohao-Project\Urban-Worm\ground_truth\groundtruth_1_labeled.csv"
 

--- a/tests/test_getSV.py
+++ b/tests/test_getSV.py
@@ -1,0 +1,55 @@
+import os
+import base64
+import pandas as pd
+from shapely.geometry import Point
+from urbanworm.utils import getSV
+from urbanworm.utils import calculate_bearing
+
+# Mapillary API Key
+MAPILLARY_KEY = "MLYATeA2wLvIqBVnUyP41955Mzz2RelHW9jMdHMitd2tyLZBC5WVkMfZBae72LGARBhbsg8n8R14WsVAEx328rDnV6pXvZAFLd61tmvriVapmJXh4lOC4AxJZCHKV9GMgZDZD"
+
+CSV_PATH = r"C:\Users\L1ght\OneDrive\Umich-School\Xiaohao-Project\Urban-Worm\ground_truth\groundtruth_1_labeled.csv"
+
+TEST_INDEX = 251
+NUM_TRIALS = 5
+
+OUTPUT_DIR = "testGetSV"
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+def test_getsv_consistency():
+    df = pd.read_csv(CSV_PATH)
+    lon, lat = eval(df.loc[TEST_INDEX, "geometry_coordinates"])  # [lon, lat]
+    print(f"\n=== Testing getSV for index {TEST_INDEX} at lon: {lon}, lat: {lat} ===")
+    centroid = Point(lon, lat)
+
+    for i in range(NUM_TRIALS):
+        print(f"\nTrial {i + 1}/{NUM_TRIALS}")
+        try:
+            images = getSV(
+                centroid=centroid,
+                epsg=3857,
+                key=MAPILLARY_KEY,
+                multi=True,
+                heading=None,
+                pitch=10,
+                fov=80,
+                width=400,
+                height=300
+            )
+            if not images:
+                print("No image returned.")
+            else:
+                print(f"Returned {len(images)} image(s).")
+                for j, img in enumerate(images):
+                    out_path = os.path.join(
+                        OUTPUT_DIR,
+                        f"debug_sv_index{TEST_INDEX}_trial{i + 1}_img{j + 1}.jpg"
+                    )
+                    with open(out_path, "wb") as f:
+                        f.write(base64.b64decode(img))
+                    print(f"Saved image {j + 1} to: {out_path}")
+        except Exception as e:
+            print(f"Error on trial {i + 1}: {e}")
+
+if __name__ == "__main__":
+    test_getsv_consistency()

--- a/tests/test_response2gdf.py
+++ b/tests/test_response2gdf.py
@@ -1,0 +1,72 @@
+import pytest
+from shapely.geometry import Point
+from urbanworm.utils import response2gdf
+from urbanworm.UrbanDataSet import QnA
+
+# QnA generate
+def make_qna(question, answer, explanation):
+    return QnA(question=question, answer=answer, explanation=explanation)
+
+def test_response2gdf_normal_single():
+    """
+    Test response2gdf with normal single-response top and street view
+    """
+    qna_dict = {
+        'lon': [-83.1],
+        'lat': [42.3],
+        'top_view': [[
+            make_qna("Top question?", "Yes", "Because it's clear.")
+        ]],
+        'street_view': [[
+            make_qna("Street question?", "No", "Blocked by tree.")
+        ]]
+    }
+
+    gdf = response2gdf(qna_dict)
+    assert len(gdf) == 1
+    assert "top_view_question1" in gdf.columns
+    assert "street_view_question1" in gdf.columns
+
+def test_response2gdf_multi_image_input():
+    """
+    Test response2gdf with multiImgInput=True structure (nested list)
+    """
+    qna_dict = {
+        'lon': [-83.2],
+        'lat': [42.4],
+        'street_view': [
+            [[
+                make_qna("Q1?", "A1", "E1"),
+                make_qna("Q2?", "A2", "E2")
+            ], [
+                make_qna("Q1?", "A3", "E3"),
+                make_qna("Q2?", "A4", "E4")
+            ]]
+        ]
+    }
+
+    gdf = response2gdf(qna_dict)
+    assert len(gdf) == 1
+    assert "street_view_question1" in gdf.columns
+
+def test_response2gdf_empty_street_view():
+    """
+    Ensure empty or malformed street_view doesn't crash
+    """
+    qna_dict = {
+        'lon': [-83.3],
+        'lat': [42.5],
+        'street_view': [[]]  # Simulate empty response from loopUnitChat
+    }
+
+    gdf = response2gdf(qna_dict)
+    assert len(gdf) == 1
+    # Should not throw IndexError even if no street_view columns
+
+def test_response2gdf_missing_all_views():
+    """
+    If no 'top_view' or 'street_view' is present, raise error
+    """
+    qna_dict = {'lon': [-83.4], 'lat': [42.6]}
+    with pytest.raises(ValueError):
+        response2gdf(qna_dict)

--- a/urbanworm/UrbanDataSet.py
+++ b/urbanworm/UrbanDataSet.py
@@ -234,7 +234,7 @@ class UrbanDataSet:
     def loopUnitChat(self, model: str = 'gemma3:12b', system: str = None, prompt: dict = None,
                      temp: float = 0.0, top_k: float = 1.0, top_p: float = 0.8,
                      type: str = 'top', epsg: int = None, multi: bool = False,
-                     sv_fov: int = 80, sv_pitch: int = 10, sv_size: list | tuple = (300, 400),
+                     sv_fov: int = 45, sv_pitch: int = 5, sv_size: list | tuple = (480, 640),
                      year: list | tuple = None, season: str = None, time_of_day: str = None,
                      one_shot_lr: list | tuple = [], multiImgInput: bool = False,
                      saveImg: bool = True, output_gdf: bool = False, disableProgressBar: bool = False) -> dict:

--- a/urbanworm/utils.py
+++ b/urbanworm/utils.py
@@ -83,8 +83,8 @@ def meters_to_degrees(meters, latitude):
 
 # Get street view images from Mapillary
 def getSV(centroid, epsg: int, key: str, multi: bool = False,
-          fov: int = 80, heading: int = None, pitch: int = 10,
-          height: int = 300, width: int = 400,
+          fov: int = 45, heading: int = None, pitch: int = 5,
+          height: int = 480, width: int = 640,
           year: list | tuple = None, season: str = None, time_of_day: str = None) -> list[str]:
     """
     getSV

--- a/urbanworm/utils.py
+++ b/urbanworm/utils.py
@@ -107,7 +107,8 @@ def getSV(centroid, epsg: int, key: str, multi: bool = False,
     """
     bbox = projection(centroid, epsg)
 
-    url = f"https://graph.mapillary.com/images?access_token={key}&fields=id,compass_angle,thumb_2048_url,captured_at,geometry&bbox={bbox}&is_pano=true"
+    # 2048 -> original to get higher resolution
+    url = f"https://graph.mapillary.com/images?access_token={key}&fields=id,compass_angle,thumb_original_url,captured_at,geometry&bbox={bbox}&is_pano=true"
     svis = []
     try:
         response = retry_request(url)

--- a/urbanworm/utils.py
+++ b/urbanworm/utils.py
@@ -238,7 +238,7 @@ def closest(centroid, response, multi=False, year=None, season=None, time_of_day
     except Exception as e:
         print(f"Error in filtering street views by time: {e}")
         return None
-    
+
     # when year is None, select the street views captured in the latest year
     if year is None:
         # sort by year
@@ -485,8 +485,8 @@ def response2df(qna_dict):
     import numpy as np
 
     def renameKey(qna_list):
-        return [{f'{key}{i+1}': qna_list[i][key] for key in qna_list[i]} for i in range(len(qna_list))]
-    
+        return [{f'{key}{i + 1}': qna_list[i][key] for key in qna_list[i]} for i in range(len(qna_list))]
+
     def extract_qna(qna, fs):
         question_num = len(qna[0])
         fs_ = [fs for i in range(question_num)]
@@ -498,7 +498,7 @@ def response2df(qna_dict):
             qna_ = renameKey(qna_)
             qna_ = {k: v for d_ in qna_ for k, v in d_.items()}
             if i == 0:
-                dic = {key:[] for key in qna_}
+                dic = {key: [] for key in qna_}
                 fields = list(dic.keys())
             for field_i in range(len(fields)):
                 try:
@@ -535,7 +535,14 @@ def response2gdf(qna_dict):
 
     def extract_qna(qna, tag, fs):
         # Recursive case for multiple street views per unit (e.g., 3 views for one location)
-        if isinstance(qna[0][0], list) and tag == 'street_view':
+        if (
+                tag == 'street_view'
+                and isinstance(qna, list)
+                and len(qna) > 0
+                and isinstance(qna[0], list)
+                and len(qna[0]) > 0
+                and isinstance(qna[0][0], list)
+        ):
             merged = {}
             for i in range(len(qna)):
                 merged_i = extract_qna(qna[i], tag, fs)
@@ -579,13 +586,22 @@ def response2gdf(qna_dict):
         top_dict = extract_qna(qna_top, 'top_view', fields)
         df_top = pd.DataFrame(top_dict)
 
-    if qna_street:
+    if qna_street and isinstance(qna_street, list) and len(qna_street) > 0:
         try:
-            fields = list(vars(qna_street[0][0]).keys())
-        except:
-            fields = list(vars(qna_street[0][0][0]).keys())
-        street_dict = extract_qna(qna_street, 'street_view', fields)
-        df_street = pd.DataFrame(street_dict)
+            if isinstance(qna_street[0], list) and len(qna_street[0]) > 0 and isinstance(qna_street[0][0], list):
+                fields = list(vars(qna_street[0][0][0]).keys())
+            elif isinstance(qna_street[0], list) and len(qna_street[0]) > 0:
+                fields = list(vars(qna_street[0][0]).keys())
+            else:
+                print("Empty or malformed street_view skipped.")
+                fields = []
+        except Exception as e:
+            print(f"Skipping street_view due to structure error: {e}")
+            fields = []
+
+        if fields:
+            street_dict = extract_qna(qna_street, 'street_view', fields)
+            df_street = pd.DataFrame(street_dict)
 
     # Determine common minimum length
     n = min(


### PR DESCRIPTION
A new test script test_getSV.py to repeatedly validate street view retrieval for a fixed coordinate
A fix for response2gdf() to safely handle empty or nested street_view responses without causing IndexError

## Summary by Sourcery

Add new tests for getSV and response2gdf and harden street view response handling to avoid index errors and malformed data in UrbanDataSet and utils

Bug Fixes:
- Fix response2gdf to safely handle empty or nested street_view data without raising IndexError
- Enhance loopUnitChat to skip and clean up entries when street_view responses are empty or malformed

Enhancements:
- Standardize type hint formatting across UrbanDataSet methods
- Add guard clauses in response2gdf for malformed street_view structures

Tests:
- Add tests/test_getSV.py to validate consistency of getSV street view retrieval
- Introduce tests/test_response2gdf.py to cover single, multi-image, empty, and missing views scenarios