### PR TITLE
fix import issues

### DIFF
--- a/urbanworm/__init__.py
+++ b/urbanworm/__init__.py
@@ -13,12 +13,18 @@ except PackageNotFoundError:  # package is not installed (e.g. running from sour
 
 # from .inference.transformers import InferenceTrans
 from .dataset import GeoTaggedData, getPhoto, getSound, getSV
-from .inference.llama import InferenceLlamacpp, InferenceOllama
 
 
 def __getattr__(name: str):
-    """Lazily expose heavy optional backends so importing urbanworm does not
-    pull in torch/unsloth or provider SDKs unless the class is requested."""
+    """Lazily expose all inference backends so importing urbanworm does not
+    pull in optional dependencies (ollama, torch, unsloth, provider SDKs)
+    unless the class is actually requested."""
+    if name == "InferenceOllama":
+        from .inference.llama import InferenceOllama as _IO
+        return _IO
+    if name == "InferenceLlamacpp":
+        from .inference.llama import InferenceLlamacpp as _IL
+        return _IL
     if name == "InferenceUnsloth":
         from .inference.unsloth import InferenceUnsloth as _IU
         return _IU

--- a/urbanworm/inference/llama.py
+++ b/urbanworm/inference/llama.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import ollama
-from ollama import Client
 from tqdm import tqdm
 
 from ..utils.checkpoint import (
@@ -13,6 +11,19 @@ from ..utils.checkpoint import (
 from ..utils.utils import *
 from .format import Response, create_format, schema_json
 from .Inference import Inference
+
+
+def _lazy_ollama():
+    """Import ollama lazily so the module can be imported without it installed."""
+    try:
+        import ollama
+        from ollama import Client
+        return ollama, Client
+    except ImportError as exc:
+        raise ImportError(
+            "InferenceOllama requires the 'ollama' extra. "
+            "Install with: pip install 'urban-worm[ollama]'"
+        ) from exc
 
 
 class InferenceOllama(Inference):
@@ -65,6 +76,7 @@ class InferenceOllama(Inference):
             dict: A dictionary includes questions/messages, responses/answers
         '''
 
+        ollama, _ = _lazy_ollama()
         ollama.pull(self.llm, stream=True)
         multiImg = False
         if image is None and audio is not None:
@@ -125,6 +137,7 @@ class InferenceOllama(Inference):
             list A list of dictionaries. Each dict includes questions/messages, responses/answers, and image base64 (if required)
         '''
 
+        ollama, _ = _lazy_ollama()
         ollama.pull(self.llm, stream=True)
 
         if self.batch_images is not None:
@@ -273,6 +286,7 @@ class InferenceOllama(Inference):
                            }
                        ]
 
+        ollama, Client = _lazy_ollama()
         if (self.ollama_key is not None) and (self.ollama_key != ''):
             client = Client(
                 host="https://ollama.com",

--- a/urbanworm/utils/utils.py
+++ b/urbanworm/utils/utils.py
@@ -1047,7 +1047,10 @@ def clip(url=None, start_ms=None, end_ms=None, output_file_path=None,
          timeout: float = _DEFAULT_TIMEOUT):
     """Download an mp3 from ``url`` and write the [start_ms, end_ms] slice."""
     try:
-        from pydub import AudioSegment  # optional [audio] extra
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=SyntaxWarning, module="pydub")
+            from pydub import AudioSegment  # optional [audio] extra
     except ImportError as exc:
         raise ImportError(
             "clip() requires pydub. Install with: pip install 'urban-worm[audio]'"
@@ -1066,7 +1069,10 @@ def clip(url=None, start_ms=None, end_ms=None, output_file_path=None,
 
 def sound_url_to_temp(url, slice: list | tuple = None, timeout: float = 30.0):
     try:
-        from pydub import AudioSegment  # optional [audio] extra
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=SyntaxWarning, module="pydub")
+            from pydub import AudioSegment  # optional [audio] extra
     except ImportError as exc:
         raise ImportError(
             "sound_url_to_temp() requires pydub. Install with: pip install 'urban-worm[audio]'"


### PR DESCRIPTION
## Summary by Sourcery

Lazily import optional dependencies and silence pydub syntax warnings to make the package importable without optional extras installed.

New Features:
- Expose inference backends via lazy attribute access so they are only imported when explicitly requested.

Bug Fixes:
- Delay importing the ollama client until it is actually needed so importing the module no longer fails when the ollama extra is missing.
- Suppress noisy SyntaxWarning messages from pydub when using audio utilities.