### PR TITLE
fix the dtype mismatch problem

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,6 +62,7 @@ schema = {
         load_in_4bit=True,
         geo_tagged_data=gtd,
         schema=schema,
+        model_dir="/data/models",   # optional: override HF cache dir
     )
 
     df = infer.batch_inference(
@@ -81,6 +82,25 @@ schema = {
         llm="hf.co/ggml-org/InternVL3-8B-Instruct-GGUF:Q8_0",
         geo_tagged_data=gtd,
         schema=schema,
+        model_dir="/data/models",   # optional: sets OLLAMA_MODELS
+    )
+
+    df = infer.batch_inference(
+        prompt="Does this house look occupied or vacant?",
+        checkpoint_path="run/labels.jsonl",
+    )
+    ```
+
+=== "llama.cpp"
+
+    ```python
+    from urbanworm import InferenceLlamacpp
+
+    infer = InferenceLlamacpp(
+        llm="ggml-org/InternVL3-8B-Instruct-GGUF:Q8_0",
+        geo_tagged_data=gtd,
+        schema=schema,
+        model_dir="/data/models",   # optional: sets HF_HUB_CACHE
     )
 
     df = infer.batch_inference(
@@ -130,6 +150,45 @@ infer = InferenceUnsloth(
     llm="unsloth/Qwen3-VL-8B-Instruct",
     load_in_4bit=True,
     max_memory={0: "10GiB", 1: "10GiB"},  # e.g. two 12 GB cards
+    schema=schema,
+)
+```
+
+---
+
+## Custom model directory
+
+All three local backends accept a `model_dir` parameter so you can control
+where downloaded model weights are stored — useful on shared servers or when
+the default home directory is on a small partition.
+
+| Backend | Effect of `model_dir` |
+|---|---|
+| `InferenceUnsloth` | Sets `cache_dir` in `FastVisionModel.from_pretrained()` (HuggingFace Hub cache) |
+| `InferenceOllama` | Sets the `OLLAMA_MODELS` env var before each `ollama.pull()` call |
+| `InferenceLlamacpp` | Sets `HF_HUB_CACHE` in the `llama-mtmd-cli` subprocess environment (only applies when downloading via `-hf`; has no effect on local GGUF paths) |
+
+```python
+# Unsloth — store weights on a large data drive
+infer = InferenceUnsloth(
+    llm="unsloth/Qwen2-VL-7B-Instruct",
+    model_dir="/data/models",
+    schema=schema,
+)
+
+# Ollama — point the client at a non-default model store
+# Note: the Ollama server itself must also be started with OLLAMA_MODELS
+# pointing to the same directory for new downloads to land there.
+infer = InferenceOllama(
+    llm="hf.co/ggml-org/InternVL3-8B-Instruct-GGUF:Q8_0",
+    model_dir="/data/models",
+    schema=schema,
+)
+
+# llama.cpp — redirect HuggingFace GGUF downloads
+infer = InferenceLlamacpp(
+    llm="ggml-org/InternVL3-8B-Instruct-GGUF:Q8_0",
+    model_dir="/data/models",
     schema=schema,
 )
 ```

--- a/urbanworm/inference/llama.py
+++ b/urbanworm/inference/llama.py
@@ -33,17 +33,27 @@ class InferenceOllama(Inference):
     Args:
         llm (str): model checkpoint.
         ollama_key (str): The Ollama API key.
+        model_dir (str, optional): Directory where Ollama stores downloaded
+            models.  Sets the ``OLLAMA_MODELS`` environment variable before
+            each ``ollama.pull`` call.  **Note:** for the running Ollama
+            server to store *new* downloads here, it must also have been
+            started with ``OLLAMA_MODELS`` pointing to the same directory
+            (e.g. ``OLLAMA_MODELS=/data/models ollama serve``).  If the
+            server is already running with a different directory, this setting
+            affects only where the client *looks*, not where the server saves.
         **kwargs: image (str|list[str]|tuple[str]), images (list|tuple), data constructor (GeoTaggedData), and schema (dict)
     '''
 
     def __init__(self,
                  llm: str = None,
                  ollama_key: str = None,
+                 model_dir: str | None = None,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.llm = llm
         self.skip_errors = True
         self.ollama_key = ollama_key
+        self.model_dir = model_dir
 
     def one_inference(self,
                       system: str = '',
@@ -77,6 +87,9 @@ class InferenceOllama(Inference):
         '''
 
         ollama, _ = _lazy_ollama()
+        if self.model_dir is not None:
+            import os
+            os.environ["OLLAMA_MODELS"] = self.model_dir
         ollama.pull(self.llm, stream=True)
         multiImg = False
         if image is None and audio is not None:
@@ -138,6 +151,9 @@ class InferenceOllama(Inference):
         '''
 
         ollama, _ = _lazy_ollama()
+        if self.model_dir is not None:
+            import os
+            os.environ["OLLAMA_MODELS"] = self.model_dir
         ollama.pull(self.llm, stream=True)
 
         if self.batch_images is not None:
@@ -356,18 +372,27 @@ class InferenceLlamacpp(Inference):
     Constructor for vision inference using MLLMs with llama.cpp
 
     Args:
-        llm (str, optional): model checkpoint to download (e.g. ggml-org/InternVL3-8B-Instruct-GGUF:Q8_0) or
-        a local path to model file (.gguf)
-        mp (str, optional): If `llm` is provided as a local path to model file (.gguf),
-        `mp` has to be provided as a local path to multimodal projector file (*mproj*.gguf).
+        llm (str, optional): model checkpoint to download (e.g.
+            ``ggml-org/InternVL3-8B-Instruct-GGUF:Q8_0``) or a local path
+            to a ``.gguf`` model file.
+        mp (str, optional): If ``llm`` is a local ``.gguf`` path, ``mp``
+            must be the local path to the multimodal projector file
+            (``*mmproj*.gguf``).
+        model_dir (str, optional): Directory used as ``HF_HUB_CACHE`` when
+            llama-mtmd-cli downloads a model via the ``-hf`` flag.  GGUF
+            files from HuggingFace will be cached here instead of the
+            default ``~/.cache/huggingface/hub``.  Has no effect when
+            ``llm`` is already a local file path.
         **kwargs: image (str|list[str]|tuple[str]), images (list|tuple), data constructor (GeoTaggedData), and schema (dict)
     '''
 
-    def __init__(self, llm:str = None, mp:str = None,
+    def __init__(self, llm: str = None, mp: str = None,
+                 model_dir: str | None = None,
                  **kwargs):
         super().__init__(**kwargs)
         self.llm = llm
         self.mp = mp
+        self.model_dir = model_dir
 
     def one_inference(self,
                       system: str = '',
@@ -705,8 +730,14 @@ class InferenceLlamacpp(Inference):
                      # "-ngl", f"{gpu_layers}"
                      ]
 
+        env = None
+        if self.model_dir is not None:
+            import os
+            env = os.environ.copy()
+            env["HF_HUB_CACHE"] = self.model_dir
+
         try:
-            res = subprocess.run(cmd, check=True, text=True, capture_output=True)
+            res = subprocess.run(cmd, check=True, text=True, capture_output=True, env=env)
         except subprocess.CalledProcessError as e:
             print("===== STDERR =====")
             print(e.stderr)

--- a/urbanworm/inference/unsloth.py
+++ b/urbanworm/inference/unsloth.py
@@ -62,6 +62,98 @@ def _lazy_imports():
     return FastVisionModel
 
 
+# ── Known error patterns that indicate a Torch compile / Accelerate conflict ─
+_COMPILE_HOOK_PATTERNS = (
+    "torch.compiler.disable",
+    "AlignDevicesHook",
+    "Skip calling",
+    "UNSLOTH_COMPILE_DISABLE",
+    "accumulated_recompile_limit",
+)
+
+
+def configure_runtime(disable_compile: bool = True) -> None:
+    """Set environment variables that control Unsloth / Torch compilation.
+
+    **Must be called before** :class:`InferenceUnsloth` is instantiated (and
+    before ``import unsloth``), because the flags are read at import time.
+    ``InferenceUnsloth.__init__`` calls this automatically when
+    ``disable_compile=True`` (the default).
+
+    Args:
+        disable_compile: When ``True`` (default), sets
+            ``UNSLOTH_COMPILE_DISABLE=1``, ``UNSLOTH_DISABLE_FAST_GENERATION=1``,
+            and ``TORCH_COMPILE_DISABLE=1``.  Trades a small throughput loss for
+            stability on long inference jobs — strongly recommended for runs
+            over ~10 k samples or when Accelerate device hooks are in use.
+    """
+    import os
+    if disable_compile:
+        os.environ.setdefault("UNSLOTH_COMPILE_DISABLE", "1")
+        os.environ.setdefault("UNSLOTH_DISABLE_FAST_GENERATION", "1")
+        os.environ.setdefault("TORCH_COMPILE_DISABLE", "1")
+        logger.debug("Unsloth/Torch compilation disabled via environment variables.")
+
+
+def clear_compile_cache() -> None:
+    """Remove the Unsloth compiled-model cache from the system temp directory.
+
+    Useful when a stale cache causes ``AlignDevicesHook`` / Torch-Dynamo
+    recompile errors.  Safe to call before loading a model.
+    """
+    import os
+    import shutil
+    import tempfile
+    from pathlib import Path
+
+    candidates = {
+        Path(tempfile.gettempdir()) / "unsloth_compiled_cache",
+        Path(os.environ.get("TEMP", "")) / "unsloth_compiled_cache",
+        Path(os.environ.get("TMP", "")) / "unsloth_compiled_cache",
+    }
+    for p in candidates:
+        if p.exists():
+            shutil.rmtree(p, ignore_errors=True)
+            logger.info("Removed Unsloth compile cache: %s", p)
+
+
+def _log_runtime_versions() -> None:
+    """Log key dependency versions at INFO level for debugging."""
+    import importlib
+    import torch
+    logger.info("torch %s | CUDA %s | GPU: %s",
+                torch.__version__,
+                torch.version.cuda or "n/a",
+                torch.cuda.get_device_name(0) if torch.cuda.is_available() else "CPU")
+    for pkg in ("transformers", "accelerate", "unsloth"):
+        try:
+            mod = importlib.import_module(pkg)
+            logger.info("%s %s", pkg, getattr(mod, "__version__", "unknown"))
+        except ImportError:
+            logger.info("%s: not installed", pkg)
+
+
+def _classify_error(exc: Exception) -> str | None:
+    """Return a hint string if ``exc`` matches a known recoverable pattern."""
+    msg = str(exc)
+    if any(p in msg for p in _COMPILE_HOOK_PATTERNS):
+        return (
+            "Torch compile + Accelerate hook conflict detected. "
+            "Re-run with disable_compile=True (already the default) and call "
+            "clear_compile_cache() before loading the model, or set "
+            "UNSLOTH_COMPILE_DISABLE=1 in your environment."
+        )
+    if "out of memory" in msg.lower():
+        return "CUDA out-of-memory. Reduce batch_size or use a smaller/more-quantised model."
+    if "expected scalar type" in msg.lower() and ("bfloat16" in msg.lower() or "float16" in msg.lower()):
+        return (
+            "Dtype mismatch between image processor (float32) and model (bf16/fp16). "
+            "This is handled automatically in _generate_batch; if it still occurs, "
+            "try passing dtype=torch.bfloat16 explicitly to InferenceUnsloth."
+        )
+    return None
+
+
 class InferenceUnsloth(Inference):
     """Vision-language model inference via Unsloth's ``FastVisionModel``.
 
@@ -81,7 +173,18 @@ class InferenceUnsloth(Inference):
             ``max_memory``.  ``None`` (default) auto-computes 90 % of each
             GPU's total capacity when multi-GPU is detected.  Example:
             ``{0: "10GiB", 1: "10GiB"}``.
+        model_dir: Local directory where HuggingFace model weights are cached.
+            Passed as ``cache_dir`` to ``FastVisionModel.from_pretrained``.
+            ``None`` (default) uses the HuggingFace default
+            (``~/.cache/huggingface/hub`` or the ``HF_HOME`` env var).
         dtype: Override the compute dtype. ``None`` = auto.
+        disable_compile: Disable Unsloth / Torch auto-compilation before the
+            model is loaded. Default ``True``.  Strongly recommended for
+            production / large-scale inference jobs — prevents the
+            ``AlignDevicesHook`` / Torch-Dynamo recompile crashes that occur
+            when Accelerate device hooks conflict with compiled code.  Sets
+            ``UNSLOTH_COMPILE_DISABLE=1``, ``UNSLOTH_DISABLE_FAST_GENERATION=1``,
+            and ``TORCH_COMPILE_DISABLE=1`` via :func:`configure_runtime`.
         skip_errors: If ``True`` (default), schema-validation failures yield
             an empty ``Response(responses=[])`` so batch loops continue
             instead of crashing. Mirrors :class:`InferenceOllama`.
@@ -98,17 +201,23 @@ class InferenceUnsloth(Inference):
         max_seq_length: int = 4096,
         device: str | None = None,
         max_memory: dict | None = None,
+        model_dir: str | None = None,
         dtype: Any = None,
+        disable_compile: bool = True,
         skip_errors: bool = True,
         **kwargs,
     ) -> None:
+        # Configure runtime env-vars before any unsloth/torch import happens.
+        configure_runtime(disable_compile)
         super().__init__(**kwargs)
         self.llm = llm or self.DEFAULT_MODEL
         self.load_in_4bit = load_in_4bit
         self.max_seq_length = max_seq_length
         self.device = device
         self.max_memory = max_memory
+        self.model_dir = model_dir
         self.dtype = dtype
+        self.disable_compile = disable_compile
         self.skip_errors = skip_errors
         self._model = None
         self._processor = None
@@ -146,6 +255,7 @@ class InferenceUnsloth(Inference):
             else:
                 device_map = "cpu"
 
+        _log_runtime_versions()
         logger.info("Loading Unsloth model %s (4bit=%s)", self.llm, self.load_in_4bit)
         load_kwargs: dict = dict(
             load_in_4bit=self.load_in_4bit,
@@ -155,10 +265,18 @@ class InferenceUnsloth(Inference):
         )
         if max_memory is not None:
             load_kwargs["max_memory"] = max_memory
+        if self.model_dir is not None:
+            load_kwargs["cache_dir"] = self.model_dir
+            logger.info("Model cache directory: %s", self.model_dir)
         self._model, self._processor = FastVisionModel.from_pretrained(
             self.llm, **load_kwargs,
         )
         FastVisionModel.for_inference(self._model)
+        # Cache the model's compute dtype so _generate_batch can cast image
+        # tensors to match (processor always emits float32; BF16/FP16 models
+        # raise "expected scalar type BFloat16 but found Float" otherwise).
+        self._model_dtype = next(self._model.parameters()).dtype
+        logger.info("Model compute dtype: %s", self._model_dtype)
 
     # ------------------------------------------------------------------
     # Public API
@@ -224,153 +342,206 @@ class InferenceUnsloth(Inference):
         top_p: float = 0.8,
         max_new_tokens: int = 512,
         batch_size: int = 1,
+        task_chunk_size: int | None = None,
         disableProgressBar: bool = False,
         checkpoint_path: str | None = None,
+        failed_log_path: str | None = None,
     ) -> pd.DataFrame:
         """Run inference over ``self.batch_images`` with optional GPU batching.
 
         Args:
-            batch_size: Number of items to process per ``model.generate`` call.
-                ``1`` (default) matches :class:`InferenceOllama` behavior.
-                Larger values trade VRAM for throughput. Practical sweet spot
-                for 7-8B VLMs on a 24GB GPU is ~4–8.
+            batch_size: Number of items per ``model.generate`` call (the GPU
+                batch).  Larger values trade VRAM for throughput; sweet spot
+                for 7–8 B VLMs on a 24 GB GPU is ~4–8.
+            task_chunk_size: Logical job partition size, independent of
+                ``batch_size``.  When set, the dataset is split into segments
+                of this size and progress is reported at the task-chunk level,
+                making long runs (e.g. 144 k samples) easier to monitor.
+                ``None`` (default) disables task-level chunking.
+                Example: ``batch_size=4, task_chunk_size=1000`` → ~145 task
+                chunks, each processed internally in batches of 4.
             checkpoint_path: Path to a JSONL file for resume-safe
                 checkpointing.  Already-completed items are skipped on the
-                next run.  Note: resume granularity is one ``batch_size``
-                chunk — the last incomplete chunk is re-processed on resume.
+                next run.
+            failed_log_path: Optional path to a CSV file where permanently
+                failed sample indices and error messages are appended.  Lets
+                you rerun only the failures later.
 
         Returns:
             DataFrame, same shape as :meth:`InferenceOllama.batch_inference`.
         """
+        import csv
+        import torch
+
         self._ensure_loaded()
 
         imgs = self.batch_images if self.batch_images is not None else self.imgs
         if not imgs:
             raise ValueError("No images to run inference on.")
 
-        # Normalize each item to a list of image strings (multi-image-per-
-        # prompt is allowed; flat str becomes a 1-element list).
         items: list[list[str]] = [
             [it] if isinstance(it, str) else list(it) for it in imgs
         ]
-
         schema = create_format(self.schema)
+        bs = max(1, int(batch_size))
+        n = len(items)
 
         # ── resume from checkpoint ───────────────────────────────────────
         done_records = load_inference_checkpoint(checkpoint_path) if checkpoint_path else []
-        bs = max(1, int(batch_size))
-        # Align start to the nearest chunk boundary so we never replay a
-        # half-finished chunk (at most bs-1 items are re-run on resume).
         start_idx = (len(done_records) // bs) * bs
         dic = restore_ollama_results(done_records[:start_idx])
 
-        n = len(items)
-        with tqdm(total=n - start_idx, desc="Processing", ncols=75, disable=disableProgressBar) as pbar:
+        # ── task-chunk boundaries for progress reporting ─────────────────
+        tcs = int(task_chunk_size) if task_chunk_size and task_chunk_size > 0 else None
+        n_task_chunks = ((n - start_idx) + tcs - 1) // tcs if tcs else 1
+
+        def _save_checkpoint(img_idx, responses):
+            if not checkpoint_path:
+                return
+            try:
+                responses_dump = [r.model_dump() for r in responses]
+            except Exception:
+                responses_dump = [dict(r) for r in responses] if responses else []
+            append_inference_checkpoint(checkpoint_path, {
+                "idx": img_idx,
+                "responses": responses_dump,
+                "data": imgs[img_idx] if isinstance(imgs[img_idx], str) else list(imgs[img_idx]),
+            })
+
+        def _log_failed(img_idx, error_msg):
+            if not failed_log_path:
+                return
+            import os
+            write_header = not os.path.exists(failed_log_path)
+            with open(failed_log_path, "a", newline="", encoding="utf-8") as fh:
+                w = csv.writer(fh)
+                if write_header:
+                    w.writerow(["idx", "data", "error"])
+                w.writerow([img_idx,
+                             imgs[img_idx] if isinstance(imgs[img_idx], str) else str(imgs[img_idx]),
+                             error_msg[:500]])
+
+        task_chunk_idx = 0
+        with tqdm(total=n - start_idx, desc="Processing", ncols=80,
+                  disable=disableProgressBar) as pbar:
             for start in range(start_idx, n, bs):
+                # ── task-chunk boundary logging ──────────────────────────
+                if tcs:
+                    rel = start - start_idx
+                    if rel % tcs == 0:
+                        task_chunk_idx = rel // tcs
+                        logger.info(
+                            "Task chunk %d/%d: rows [%d, %d)",
+                            task_chunk_idx + 1, n_task_chunks,
+                            start, min(start + tcs, n),
+                        )
+
                 chunk = items[start:start + bs]
+                responses_list = self._run_chunk_with_retry(
+                    chunk=chunk,
+                    start=start,
+                    system=system,
+                    prompt=prompt,
+                    schema=schema,
+                    temp=temp,
+                    top_k=top_k,
+                    top_p=top_p,
+                    max_new_tokens=max_new_tokens,
+                )
+
+                for k, (responses, err) in enumerate(responses_list):
+                    img_idx = start + k
+                    dic["responses"].append(responses)
+                    dic["data"].append(imgs[img_idx])
+                    if responses:
+                        _save_checkpoint(img_idx, responses)
+                    if err is not None:
+                        _log_failed(img_idx, err)
+
+                # Proactively free reserved-but-unused allocator pool.
                 try:
-                    chunk_resp = self._generate_batch(
-                        systems=[system] * len(chunk),
-                        prompts=[prompt] * len(chunk),
-                        images_per_prompt=chunk,
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                except Exception:
+                    pass
+
+                pbar.update(len(chunk))
+
+        self.results = dic
+        return self.to_df(output=True)
+
+    def _run_chunk_with_retry(
+        self,
+        chunk: list,
+        start: int,
+        system: str,
+        prompt: str,
+        schema,
+        temp: float,
+        top_k: int,
+        top_p: float,
+        max_new_tokens: int,
+    ) -> list[tuple[list, str | None]]:
+        """Run ``chunk`` through the model, retrying with halved batch size on failure.
+
+        Returns a list of ``(responses, error_msg)`` tuples — one per item.
+        ``error_msg`` is ``None`` on success and a string on permanent failure.
+        Retry ladder: ``len(chunk)`` → ``len(chunk) // 2`` → … → ``1`` → stub.
+        """
+        import torch
+
+        # results[i] = (responses, error) or None if not yet processed
+        results: list[tuple[list, str | None] | None] = [None] * len(chunk)
+
+        current_bs = len(chunk)
+        while current_bs >= 1:
+            pending = [i for i, r in enumerate(results) if r is None]
+            if not pending:
+                break
+
+            for sub_start in range(0, len(pending), current_bs):
+                sub_idx = pending[sub_start: sub_start + current_bs]
+                sub_items = [chunk[i] for i in sub_idx]
+                try:
+                    sub_resp = self._generate_batch(
+                        systems=[system] * len(sub_items),
+                        prompts=[prompt] * len(sub_items),
+                        images_per_prompt=sub_items,
                         schema=schema,
                         temp=temp,
                         top_k=top_k,
                         top_p=top_p,
                         max_new_tokens=max_new_tokens,
                     )
-                    for j, r in enumerate(chunk_resp):
-                        img_idx = start + j
-                        responses = r.responses
-                        dic["responses"].append(responses)
-                        dic["data"].append(imgs[img_idx])
-
-                        if checkpoint_path:
-                            try:
-                                responses_dump = [item.model_dump() for item in responses]
-                            except Exception:
-                                responses_dump = [dict(item) for item in responses] if responses else []
-                            append_inference_checkpoint(checkpoint_path, {
-                                "idx": img_idx,
-                                "responses": responses_dump,
-                                "data": imgs[img_idx] if isinstance(imgs[img_idx], str)
-                                        else list(imgs[img_idx]),
-                            })
-                except Exception as e:
-                    import torch
-                    is_oom = isinstance(e, torch.cuda.OutOfMemoryError) or (
-                        "out of memory" in str(e).lower()
-                    )
-                    if is_oom and len(chunk) > 1:
-                        # OOM on a multi-item chunk: clear the cache and retry
-                        # each item individually so we lose as little data as
-                        # possible.  The recompile-limit cascade is also caused
-                        # by OOM, so recovering cleanly here prevents it.
-                        logger.warning(
-                            "batch_inference: chunk [%d, %d) OOM; clearing cache "
-                            "and retrying item-by-item.", start, start + len(chunk),
-                        )
+                    for list_pos, i in enumerate(sub_idx):
+                        results[i] = (sub_resp[list_pos].responses, None)
+                    if torch.cuda.is_available():
                         torch.cuda.empty_cache()
-                        for k, single_item in enumerate(chunk):
-                            img_idx = start + k
-                            try:
-                                single_resp = self._generate_batch(
-                                    systems=[system],
-                                    prompts=[prompt],
-                                    images_per_prompt=[single_item],
-                                    schema=schema,
-                                    temp=temp,
-                                    top_k=top_k,
-                                    top_p=top_p,
-                                    max_new_tokens=max_new_tokens,
-                                )
-                                responses = single_resp[0].responses
-                                torch.cuda.empty_cache()
-                            except Exception as e2:
-                                logger.warning(
-                                    "batch_inference: item %d failed after OOM retry "
-                                    "(%s); filling stub.", img_idx, e2,
-                                )
-                                torch.cuda.empty_cache()
-                                responses = []
-                            dic["responses"].append(responses)
-                            dic["data"].append(imgs[img_idx])
-                            if checkpoint_path and responses:
-                                try:
-                                    responses_dump = [item.model_dump() for item in responses]
-                                except Exception:
-                                    responses_dump = [dict(item) for item in responses] if responses else []
-                                append_inference_checkpoint(checkpoint_path, {
-                                    "idx": img_idx,
-                                    "responses": responses_dump,
-                                    "data": imgs[img_idx] if isinstance(imgs[img_idx], str)
-                                            else list(imgs[img_idx]),
-                                })
-                    else:
-                        logger.warning(
-                            "batch_inference: chunk [%d, %d) failed (%s); "
-                            "filling stub responses.", start, start + len(chunk), e,
-                        )
-                        if is_oom:
-                            import torch as _torch
-                            _torch.cuda.empty_cache()
-                        for k in range(len(chunk)):
-                            img_idx = start + k
-                            dic["responses"].append([])
-                            dic["data"].append(imgs[img_idx])
-                else:
-                    # Successful chunk — proactively free the allocator's
-                    # reserved-but-unused pool to keep fragmentation low.
-                    try:
-                        import torch as _torch
-                        if _torch.cuda.is_available():
-                            _torch.cuda.empty_cache()
-                    except Exception:
-                        pass
-                pbar.update(len(chunk))
+                except Exception as exc:
+                    hint = _classify_error(exc)
+                    if hint:
+                        logger.warning("[urbanworm|HINT] %s", hint)
+                    if current_bs == 1:
+                        # Final retry exhausted — fill stubs and log failures.
+                        err_str = str(exc)
+                        for i in sub_idx:
+                            abs_idx = start + i
+                            logger.warning(
+                                "batch_inference: item %d permanently failed (%s); "
+                                "filling stub.", abs_idx, err_str[:120],
+                            )
+                            results[i] = ([], err_str)
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
 
-        self.results = dic
-        return self.to_df(output=True)
+            current_bs //= 2
+
+        # Any remaining None slots (shouldn't happen, but be defensive)
+        for i, r in enumerate(results):
+            if r is None:
+                results[i] = ([], "unknown — slot unfilled after retry ladder")
+
+        return results  # type: ignore[return-value]
 
     def to_df(self, output: bool = True) -> pd.DataFrame | None:
         """Convert ``self.results`` into a DataFrame. Mirrors InferenceOllama."""
@@ -444,6 +615,16 @@ class InferenceUnsloth(Inference):
             return_tensors="pt",
             padding=True,
         ).to(first_device)
+
+        # The processor always emits pixel_values (and related image tensors)
+        # as float32, but BF16/FP16 models expect their native dtype.
+        # Cast every floating-point tensor in the batch to the model dtype.
+        # Integer tensors (input_ids, attention_mask, etc.) are left as-is.
+        model_dtype = getattr(self, "_model_dtype", None) or next(self._model.parameters()).dtype
+        for key in list(inputs.keys()):
+            val = inputs[key]
+            if torch.is_tensor(val) and val.is_floating_point():
+                inputs[key] = val.to(model_dtype)
 
         # 3) Generate
         do_sample = bool(temp and temp > 0)

--- a/urbanworm/inference/unsloth.py
+++ b/urbanworm/inference/unsloth.py
@@ -120,6 +120,7 @@ def clear_compile_cache() -> None:
 def _log_runtime_versions() -> None:
     """Log key dependency versions at INFO level for debugging."""
     import importlib
+
     import torch
     logger.info("torch %s | CUDA %s | GPU: %s",
                 torch.__version__,
@@ -371,6 +372,7 @@ class InferenceUnsloth(Inference):
             DataFrame, same shape as :meth:`InferenceOllama.batch_inference`.
         """
         import csv
+
         import torch
 
         self._ensure_loaded()


### PR DESCRIPTION
## Summary by Sourcery

Improve Unsloth-based inference stability and monitoring while adding configurable model-cache directories across backends.

New Features:
- Allow specifying a custom model cache directory for Unsloth, Ollama, and llama.cpp backends via a model_dir parameter.
- Add task_chunk_size and failed_log_path options to batch_inference for finer-grained progress tracking and persistent logging of failed samples.
- Introduce runtime configuration helpers to control Unsloth/Torch compilation behavior and clear compiled-model caches.

Bug Fixes:
- Automatically align image tensor dtypes with the loaded model's compute dtype to prevent float32 vs bf16/fp16 mismatches during Unsloth inference.
- Improve error handling and recovery in batch_inference with a retry ladder that shrinks batch size on failure and classifies common CUDA and compile-hook errors.

Enhancements:
- Log key runtime and dependency versions when loading Unsloth models for easier debugging of environment-related issues.
- Refine checkpointing and resume behavior by aligning to batch boundaries and centralizing checkpoint writes per item.
- Proactively release unused CUDA memory after batch execution to reduce fragmentation and OOM cascades.

Documentation:
- Extend the quickstart guide with examples for model_dir across backends and a dedicated section explaining how custom model directories are handled.